### PR TITLE
Add datetime column type 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Added datetime column type option
+
 ## 1.2.5 - 2021-07-02
 ### Fixed
 - Reverted [#66](https://github.com/besteadfast/craft-preparse-field/pull/66) due to bug where sometimes the element couldn't be re-fetched from the database ([#70](https://github.com/besteadfast/craft-preparse-field/issues/70), [#71](https://github.com/besteadfast/craft-preparse-field/issues/71), [#72](https://github.com/besteadfast/craft-preparse-field/issues/72), [#73](https://github.com/besteadfast/craft-preparse-field/issues/73))

--- a/src/services/PreparseFieldService.php
+++ b/src/services/PreparseFieldService.php
@@ -13,6 +13,7 @@ use besteadfast\preparsefield\fields\PreparseFieldType;
 use Craft;
 use craft\base\Component;
 use craft\base\Element;
+use craft\helpers\DateTimeHelper;
 use craft\web\View;
 use craft\db\mysql\Schema;
 use yii\base\Exception;
@@ -124,6 +125,13 @@ class PreparseFieldService extends Component
             }
 
             return number_format(trim($fieldValue), 0, '.', '');
+        } else if ($columnType === Schema::TYPE_DATETIME) {
+            $fieldValue = \trim($fieldValue);
+            if (!$fieldValue || !$date = DateTimeHelper::toDateTime($fieldValue, true)) {
+                // Return an empty string rather than null to clear out existing DateTime value (null would mean "no change")
+                return '';
+            }
+            return $date;
         }
 
         return $fieldValue;

--- a/src/templates/_components/fields/_input.twig
+++ b/src/templates/_components/fields/_input.twig
@@ -25,16 +25,17 @@
 {% else %}
     {# Setup our field #}
     {% if displayType == 'date' %}
-        {{ forms.date({
+        {{ forms.dateTimeField({
             value: value,
-            disabled: true
+            disabled: true,
         }) }}
-        {{ forms.time({
-            value: value,
-            disabled: true
-        }) }}
+        <style>
+            #{{ namespacedId }}-field .clear-btn {
+                display: none;
+            }
+        </style>
     {% elseif displayType == 'textarea' %}
-        {{ forms.textarea( {
+        {{ forms.textarea({
             value: value,
             disabled: not field['allowSelect'],
             readonly: field['allowSelect'],

--- a/src/templates/_components/fields/_input.twig
+++ b/src/templates/_components/fields/_input.twig
@@ -14,30 +14,37 @@
 
 {% import "_includes/forms" as forms %}
 
-{% if field['displayType'] == 'hidden' %}
+{% set displayType = displayType ?? 'hidden' %}
+
+{% if displayType == 'hidden' %}
     <style>
         #{{ namespacedId }}-field {
             display: none;
         }
     </style>
-{% endif %}
-
-{# Setup our field #}
-{% if field['displayType'] == 'textarea' %}
-    {{ forms.textarea( {
-        id: name,
-        name: name,
-        value: value,
-        disabled: not field['allowSelect'],
-        readonly: field['allowSelect'],
-        rows: field['textareaRows']
-    }) }}
 {% else %}
-    {{ forms.text({
-        id: name,
-        name: name,
-        value: value,
-        disabled: not field['allowSelect'],
-        readonly: field['allowSelect']
-    }) }}
+    {# Setup our field #}
+    {% if displayType == 'date' %}
+        {{ forms.date({
+            value: value,
+            disabled: true
+        }) }}
+        {{ forms.time({
+            value: value,
+            disabled: true
+        }) }}
+    {% elseif displayType == 'textarea' %}
+        {{ forms.textarea( {
+            value: value,
+            disabled: not field['allowSelect'],
+            readonly: field['allowSelect'],
+            rows: field['textareaRows']
+        }) }}
+    {% else %}
+        {{ forms.text({
+            value: value,
+            disabled: not field['allowSelect'],
+            readonly: field['allowSelect']
+        }) }}
+    {% endif %}
 {% endif %}

--- a/src/templates/_components/fields/_settings.twig
+++ b/src/templates/_components/fields/_settings.twig
@@ -16,7 +16,7 @@
 
 {{ forms.textareaField( {
     label: "Twig code to parse"|t,
-    instructions: "Enter the twig code that you want to parse after the entry has been saved."|t,
+    instructions: "Enter the twig code that you want to parse after the entry has been saved.\nIf the column type is set to Date (datetime), the parsed Twig should output a date formatted as `Y-m-d H:i:s`."|t,
     id: 'fieldTwig',
     name: 'fieldTwig',
     value: field['fieldTwig'],
@@ -81,7 +81,7 @@
 
 {{ forms.field({
     label: "Display Type"|t,
-    instructions: "Select how this field is to be shown in the edit page."|t,
+    instructions: "Select how this field is to be shown in the edit page.\nIf the column type is set to Date (datetime), any other option than \"Hidden\" will render the field value in a disabled datepicker."|t,
     id: 'displayType',
 }, displayType) }}
 


### PR DESCRIPTION
This PR adds a "Date (datetime)" option to the Column Type option in Preparse's field settings, which enables date based queries on Preparse values.  

Preparsed Twig for fields using datetime as their content column should render a date in the `Y-m-d H:i:s` format (as mentioned in the field settings template). 

If a datetime Preparse field's Display Mode setting is set to anything other than hidden, the field value will render as a disabled datepicker (see screenshot below).

![image](https://user-images.githubusercontent.com/298510/91906683-e80c4300-eca8-11ea-85b6-3bb52b5bf78b.png)
