### PR TITLE
Don't parse revisions

### DIFF
--- a/src/PreparseField.php
+++ b/src/PreparseField.php
@@ -97,6 +97,10 @@ class PreparseField extends Plugin
         // After save element event handler
         Event::on(Elements::class, Elements::EVENT_AFTER_SAVE_ELEMENT,
             function (ElementEvent $event) {
+                if ($event->element->getIsRevision()) {
+                    return;
+                }
+
                 /** @var Element $element */
                 $element = $event->element;
                 $key = $element->id . '__' . $element->siteId;


### PR DESCRIPTION
This PR fixes #64, by ignoring the `EVENT_AFTER_SAVE_ELEMENT` event for element revisions, which shouldn’t be tampered with anyway.