### PR TITLE
Avoid resaving element in Elements::EVENT_AFTER_SAVE_ELEMENT event handler

### DIFF
--- a/src/PreparseField.php
+++ b/src/PreparseField.php
@@ -112,37 +112,31 @@ class PreparseField extends Plugin
                     return;
                 }
 
-                if ($event->element->getId()) {
-                    // Since it's already been saved, we need to fetch the element again.
-                    /** @var Element $element */
-                    $element = Craft::$app->elements->getElementById($event->element->getId(), null, $event->element->siteId);
-                    $key = $element->id . '__' . $element->siteId;
-                    
-                    if (!isset($this->preparsedElements['onSave'][$key])) {
-                        $this->preparsedElements['onSave'][$key] = true;
-                        
-                        // Still pass the event element here to generate the preparse fields content, not the $element fetched above.
-                        $content = self::$plugin->preparseFieldService->getPreparseFieldsContent($event->element, 'onSave');
-                    
-                        if (!empty($content)) {
-                            $this->resetUploads();
-                        
-                            if ($element instanceof Asset) {
-                                $element->setScenario(Element::SCENARIO_DEFAULT);
-                            }
-                        
-                            $element->setFieldValues($content);
-                            $success = Craft::$app->elements->saveElement($element, true, false);
+                /** @var Element $element */
+                $element = $event->element;
+                $key = $element->id . '__' . $element->siteId;
 
-                            // if no success, log error
-                            if (!$success) {
-                                Craft::error('Couldn’t save element with id “' . $element->id . '”', __METHOD__);
-                            }
+                if (!isset($this->preparsedElements['onSave'][$key])) {
+                    $this->preparsedElements['onSave'][$key] = true;
+
+                    // Still pass the event element here to generate the preparse fields content, not the $element fetched above.
+                    $content = self::$plugin->preparseFieldService->getPreparseFieldsContent($event->element, 'onSave');
+
+                    if (!empty($content)) {
+                        $this->resetUploads();
+
+                        $element->setFieldValues($content);
+                        $success = Craft::$app->getContent()->saveContent($element);
+
+                        // if no success, log error
+                        if (!$success) {
+                            Craft::error('Couldn’t save element with id “' . $element->id . '”', __METHOD__);
                         }
-
-                        unset($this->preparsedElements['onSave'][$key]);
                     }
+
+                    unset($this->preparsedElements['onSave'][$key]);
                 }
+
             }
         );
 

--- a/src/PreparseField.php
+++ b/src/PreparseField.php
@@ -119,7 +119,6 @@ class PreparseField extends Plugin
                 if (!isset($this->preparsedElements['onSave'][$key])) {
                     $this->preparsedElements['onSave'][$key] = true;
 
-                    // Still pass the event element here to generate the preparse fields content, not the $element fetched above.
                     $content = self::$plugin->preparseFieldService->getPreparseFieldsContent($event->element, 'onSave');
 
                     if (!empty($content)) {


### PR DESCRIPTION
This PR rolls back the changes made in #66, which attempted to fix issues with Matrix blocks being deleted in certain cases. #66 solves this by re-fetching the newly saved element from the database inside the `Elements::EVENT_AFTER_SAVE_ELEMENT` event handler, but unfortunately this approach seems to have caused other issues, such as #71, #70, #73 and possibly #72.

**Rather than attempting to work around the problems introduced by #66, this PR takes a different approach to solving the original issue by updating the content table directly via the [`Content::saveContent()` ](https://github.com/craftcms/cms/blob/develop/src/services/Content.php#L147) method, instead of re-saving the element itself.** This appears to save the preparsed content properly after the element is saved, whilst keeping relational data (i.e. Matrix blocks) intact.

I was able to reproduce both #71, #70 and #73 before applying this patch, and I'm *not* able to reproduce them after. I'm also unable to reproduce the original issue (#64, #66) with the patch applied. Additionally, I've tested that the patch works as intended on both multi-site and single-site setups, and when using the `resave` CLI command.

A final note; I removed the `$element->setScenario()` call inside the `EVENT_AFTER_SAVE_ELEMENT` event handler, simply because it should be redundant as the element is no longer re-saved.

**Disclaimer:** 

Unfortunately I'm not 100% confident that updating the content table directly, vs. actually re-saving the element, won't cause any unwanted side effects. As far as I've been able to test, it works (and, *not* resaving the element in the an `EVENT_AFTER_SAVE_ELEMENT` event handler also seems like a cleaner approach to me overall) but it could also be a Very Bad Idea. TL;DR, it might be good to get an actual expert's eyes on this PR before considering to merge. Maybe @brandonkelly has the time for a quick review? 😇 

Fixes #71  
Fixes #70  
Fixes #73  