### PR TITLE
refactor: Add support for craft-twigfield

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	],
 	"require": {
 		"craftcms/cms": "^3.2.0",
-		"nystudio107/craft-twigfield": "dev-develop"
+		"nystudio107/craft-twigfield": "^1.0.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 		}
 	],
 	"require": {
-		"craftcms/cms": "^3.2.0"
+		"craftcms/cms": "^3.2.0",
+		"nystudio107/craft-twigfield": "dev-develop"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/fields/PreparseFieldType.php
+++ b/src/fields/PreparseFieldType.php
@@ -15,7 +15,6 @@ use craft\base\PreviewableFieldInterface;
 use craft\base\SortableFieldInterface;
 use craft\db\mysql\Schema;
 use craft\helpers\Db;
-use nystudio107\twigfield\validators\TwigTemplateValidator;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -70,25 +69,24 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface, Sort
     public function rules()
     {
         $rules = parent::rules();
-        $rules = array_merge($rules, [
-            ['fieldTwig', TwigTemplateValidator::class],
-            ['columnType', 'string'],
-            ['columnType', 'default', 'value' => ''],
-            ['decimals', 'number'],
-            ['decimals', 'default', 'value' => 0],
-            ['textareaRows', 'number'],
-            ['textareaRows', 'default', 'value' => 5],
-            ['parseBeforeSave', 'boolean'],
-            ['parseBeforeSave', 'default', 'value' => false],
-            ['parseOnMove', 'boolean'],
-            ['parseOnMove', 'default', 'value' => false],
-            ['displayType', 'string'],
-            ['displayType', 'default', 'value' => 'hidden'],
-            ['allowSelect', 'boolean'],
-            ['allowSelect', 'default', 'value' => false],
-        ]);
-
-        return $rules;
+		return array_merge($rules, [
+			['fieldTwig', 'string'],
+			['fieldTwig', 'default', 'value' => ''],
+			['columnType', 'string'],
+			['columnType', 'default', 'value' => ''],
+			['decimals', 'number'],
+			['decimals', 'default', 'value' => 0],
+			['textareaRows', 'number'],
+			['textareaRows', 'default', 'value' => 5],
+			['parseBeforeSave', 'boolean'],
+			['parseBeforeSave', 'default', 'value' => false],
+			['parseOnMove', 'boolean'],
+			['parseOnMove', 'default', 'value' => false],
+			['displayType', 'string'],
+			['displayType', 'default', 'value' => 'hidden'],
+			['allowSelect', 'boolean'],
+			['allowSelect', 'default', 'value' => false],
+		]);
     }
 
     /**

--- a/src/fields/PreparseFieldType.php
+++ b/src/fields/PreparseFieldType.php
@@ -15,6 +15,7 @@ use craft\base\PreviewableFieldInterface;
 use craft\base\SortableFieldInterface;
 use craft\db\mysql\Schema;
 use craft\helpers\Db;
+use nystudio107\twigfield\validators\TwigTemplateValidator;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -70,8 +71,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface, Sort
     {
         $rules = parent::rules();
         $rules = array_merge($rules, [
-            ['fieldTwig', 'string'],
-            ['fieldTwig', 'default', 'value' => ''],
+            ['fieldTwig', TwigTemplateValidator::class],
             ['columnType', 'string'],
             ['columnType', 'default', 'value' => ''],
             ['decimals', 'number'],
@@ -103,7 +103,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface, Sort
 
         return $this->columnType;
     }
-	
+
 	/**
 	 * @return null|string
 	 * @throws LoaderError
@@ -137,7 +137,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface, Sort
             ]
         );
     }
-	
+
 	/**
 	 * @param mixed $value
 	 * @param ElementInterface|null $element

--- a/src/templates/_components/fields/_settings.twig
+++ b/src/templates/_components/fields/_settings.twig
@@ -20,9 +20,10 @@
     instructions: "Enter the twig code that you want to parse after the entry has been saved."|t,
     id: 'fieldTwig',
     name: 'fieldTwig',
-    value: field['fieldTwig'],
+    value: field.fieldTwig,
     class: 'code',
-    rows: 10
+    rows: 10,
+    errors: field.getErrors('fieldTwig'),
 }, "Twigfield", "monaco-editor-background-frame") }}
 
 {% set columnType %}

--- a/src/templates/_components/fields/_settings.twig
+++ b/src/templates/_components/fields/_settings.twig
@@ -20,10 +20,9 @@
     instructions: "Enter the twig code that you want to parse after the entry has been saved."|t,
     id: 'fieldTwig',
     name: 'fieldTwig',
-    value: field.fieldTwig,
+    value: field['fieldTwig'],
     class: 'code',
     rows: 10,
-    errors: field.getErrors('fieldTwig'),
 }, "Twigfield", "monaco-editor-background-frame") }}
 
 {% set columnType %}

--- a/src/templates/_components/fields/_settings.twig
+++ b/src/templates/_components/fields/_settings.twig
@@ -13,8 +13,9 @@
 #}
 
 {% import "_includes/forms" as forms %}
+{% import "twigfield/twigfield" as twigfield %}
 
-{{ forms.textareaField( {
+{{ twigfield.textareaField( {
     label: "Twig code to parse"|t,
     instructions: "Enter the twig code that you want to parse after the entry has been saved."|t,
     id: 'fieldTwig',
@@ -22,7 +23,7 @@
     value: field['fieldTwig'],
     class: 'code',
     rows: 10
-}) }}
+}, "Twigfield", "monaco-editor-background-frame") }}
 
 {% set columnType %}
     {{ forms.select({


### PR DESCRIPTION
Adds support for craft-twigfield, which changes this static text area input:

<img width="969" alt="Screen Shot 2022-06-12 at 3 19 25 AM" src="https://user-images.githubusercontent.com/7570798/173222528-2b67d5cd-8dbd-44c2-8b09-461d0bfc6b39.png">

...into a syntax-highlighted Twig field with autocomplete support for the Twig and Craft APIs:

<img width="980" alt="Screen Shot 2022-06-12 at 3 31 17 AM" src="https://user-images.githubusercontent.com/7570798/173222547-0d64b9e4-abe4-47c0-ab8d-4cdf6197f94d.png">
