### PR TITLE
[feat] - v4 Code Editor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	],
 	"require": {
 		"craftcms/cms": "^4.0.0",
-		"nystudio107/craft-twigfield": "^1.0.0",
+		"nystudio107/craft-code-editor": "^1.0.0",
 		"php": "^8.0.2"
 	},
 	"autoload": {

--- a/src/templates/_components/fields/_settings.twig
+++ b/src/templates/_components/fields/_settings.twig
@@ -13,8 +13,13 @@
 #}
 
 {% import "_includes/forms" as forms %}
-{% import "twigfield/twigfield" as twigfield %}
+{% import "codeeditor/codeEditor" as codeEditor %}
 
+{% set monacoOptions = {
+} %}
+{% set codeEditorOptions = {
+    wrapperClass:"monaco-editor-background-frame"
+} %}
 {{ twigfield.textareaField( {
     label: "Twig code to parse"|t,
     instructions: "Enter the twig code that you want to parse after the entry has been saved.\nIf the column type is set to Date (datetime), the parsed Twig should output a date formatted as `Y-m-d H:i:s`."|t,
@@ -23,7 +28,7 @@
     value: field['fieldTwig'],
     class: 'code',
     rows: 10,
-}, "Twigfield", "monaco-editor-background-frame") }}
+}, "CodeField", monacoOptions, codeEditorOptions) }}
 
 {% set columnType %}
     {{ forms.select({


### PR DESCRIPTION
This PR is for the Craft 4 version of Preparse

This PR updates Preparse to use [Code Editor](https://github.com/nystudio107/craft-code-editor) rather than Twigfield (which has been deprecated). Code Editor is a general-purpose code editor that _also_ does Twig & autocomplete.

Code Editor also has been refactored to TypeScript, supports light/dark themes, and has a tweaked/improved API.