### PR TITLE
Add JSON Column Type

### DIFF
--- a/src/fields/PreparseFieldType.php
+++ b/src/fields/PreparseFieldType.php
@@ -118,6 +118,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface, Sort
             Schema::TYPE_INTEGER => Craft::t('preparse-field', 'Number (integer)'),
             Schema::TYPE_DECIMAL => Craft::t('preparse-field', 'Number (decimal)'),
             Schema::TYPE_FLOAT => Craft::t('preparse-field', 'Number (float)'),
+            Schema::TYPE_JSON => Craft::t('preparse-field', 'JSON'),
         ];
 
         $displayTypes = [

--- a/src/services/PreparseFieldService.php
+++ b/src/services/PreparseFieldService.php
@@ -16,6 +16,7 @@ use craft\base\Element;
 use craft\web\View;
 use craft\db\mysql\Schema;
 use yii\base\Exception;
+use yii\db\Expression;
 
 /**
  * PreparseFieldService Service
@@ -124,6 +125,13 @@ class PreparseFieldService extends Component
             }
 
             return number_format(trim($fieldValue), 0, '.', '');
+        }
+
+        if ($columnType === Schema::TYPE_JSON) {
+            // If this is a JSON field, return it as an expression so it is not escaped
+            return new Expression(':json', [
+                ':json' => $fieldValue,
+            ]);
         }
 
         return $fieldValue;


### PR DESCRIPTION
This adds a native JSON column type. The nice thing about this is you can use Preparse to cache an arbitrary amount of data in to a JSON field and then have MySQL generated columns index on whatever keys you'd like out of that JSON. We're using this liberally to bubble some deeply nested relationships up to a grandparent so we can index/search/sort on it more easily.

/ht @pixleight for the work on this!

/note This is an updated PR from #90, which had some conflicts. This resolves those conflicts.